### PR TITLE
fix: Resolve GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,37 @@ env:
 
 jobs:
   check:
-    name: "\u2705 Check Code Quality"
+    name: "Check Code Quality"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          rust-version: stable
-          cache-key-suffix: check
+          components: rustfmt, clippy
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          experimental: true
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-check-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-check-cargo-
+
+      - name: Install mise dependencies
+        run: mise install
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -40,50 +61,98 @@ jobs:
         run: cargo test --doc --all-features -- --ignored
 
   security:
-    name: "\uD83D\uDD12 Security Audit"
+    name: "Security Audit"
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
         with:
-          rust-version: stable
-          components: ''
-          cache-key-suffix: security
+          experimental: true
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-security-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-security-cargo-
+
+      - name: Install mise dependencies
+        run: mise install
 
       - name: Audit dependencies
         run: cargo audit
 
   msrv:
-    name: "\uD83E\uDD80 Minimum Supported Rust Version"
+    name: "Minimum Supported Rust Version"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          rust-version: ${{ env.MSRV }}
-          components: ''
-          cache-key-suffix: msrv
+          toolchain: ${{ env.MSRV }}
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-msrv-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-msrv-cargo-
 
       - name: Check MSRV
         run: cargo check --all-targets --all-features
 
   beta:
-    name: "\uD83E\uDDEA Beta Rust Channel"
+    name: "Beta Rust Channel"
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@beta
         with:
-          rust-version: beta
-          cache-key-suffix: beta
+          components: rustfmt, clippy
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          experimental: true
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-beta-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-beta-cargo-
+
+      - name: Install mise dependencies
+        run: mise install
 
       - name: Check formatting
         run: cargo fmt --all --check

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -92,10 +92,10 @@ jobs:
 
             // Map required check names to actual GitHub Actions job names
             const checkNameMap = {
-              'check': '\u2705 Check Code Quality',
-              'security': '\uD83D\uDD12 Security Audit',
-              'msrv': '\uD83E\uDD80 Minimum Supported Rust Version',
-              'beta': '\uD83E\uDDEA Beta Rust Channel'
+              'check': 'Check Code Quality',
+              'security': 'Security Audit',
+              'msrv': 'Minimum Supported Rust Version',
+              'beta': 'Beta Rust Channel'
             };
 
             const requiredChecks = Object.keys(checkNameMap);

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,7 +12,6 @@ jobs:
     if: ${{ github.repository_owner == 'ilaborie' }}
     permissions:
       contents: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,16 +20,13 @@ jobs:
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
-        id: auth
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,11 +2,11 @@
 
 # Examples - do not publish
 [[package]]
-name = "github-api"
+name = "github-api-example"
 publish = false
 
 [[package]]
-name = "wikipedia-api"
+name = "wikipedia-api-example"
 publish = false
 
 # Core library - publish


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions workflow failures by:

- **Fix package names in `release-plz.toml`**: Changed `github-api` to `github-api-example` and `wikipedia-api` to `wikipedia-api-example` to match actual package names in `examples/*/Cargo.toml`
- **Replace trusted publishing with `CARGO_REGISTRY_TOKEN`**: Removed `rust-lang/crates-io-auth-action@v1` which required trusted publishing setup on crates.io. Now uses `CARGO_REGISTRY_TOKEN` secret directly
- **Inline CI workflow setup steps**: Replaced composite action with inline steps to resolve workflow file validation issues
- **Update dependabot-auto-merge**: Updated job name mapping to match new CI job names

## Required Manual Action

Before merging, please add the `CARGO_REGISTRY_TOKEN` secret:
1. Go to https://crates.io/settings/tokens
2. Create an API token with publish scope
3. Add it as repository secret: Settings → Secrets → Actions → `CARGO_REGISTRY_TOKEN`

## Test plan

- [x] `mise check` passes locally
- [ ] CI workflow runs successfully after push
- [ ] Release-plz workflow runs successfully after merge