### PR TITLE
chore: release v0.1.0

### DIFF
--- a/lib/pincer-core/CHANGELOG.md
+++ b/lib/pincer-core/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-core-v0.1.0) - 2025-12-31
+
+### Added
+
+- Initial version

--- a/lib/pincer-macro/CHANGELOG.md
+++ b/lib/pincer-macro/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-macro-v0.1.0) - 2025-12-31
+
+### Added
+
+- Initial version

--- a/lib/pincer/CHANGELOG.md
+++ b/lib/pincer/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-v0.1.0) - 2025-12-31
+
+### Added
+
+- Initial version


### PR DESCRIPTION



## 🤖 New release

* `pincer-core`: 0.1.0
* `pincer-macro`: 0.1.0
* `pincer`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `pincer-core`

<blockquote>

## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-core-v0.1.0) - 2025-12-31

### Added

- Initial version
</blockquote>

## `pincer-macro`

<blockquote>

## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-macro-v0.1.0) - 2025-12-31

### Added

- Initial version
</blockquote>

## `pincer`

<blockquote>

## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-v0.1.0) - 2025-12-31

### Added

- Initial version
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).