### PR TITLE
fix: Add version to workspace internal crate dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,9 +94,9 @@ insta = { version = "1.42", features = ["yaml"] }
 wiremock = "0.6"
 
 # Internal crates
-pincer-core = { path = "lib/pincer-core" }
-pincer-macro = { path = "lib/pincer-macro" }
-pincer = { path = "lib/pincer" }
+pincer-core = { path = "lib/pincer-core", version = "0.1.0" }
+pincer-macro = { path = "lib/pincer-macro", version = "0.1.0" }
+pincer = { path = "lib/pincer", version = "0.1.0" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"


### PR DESCRIPTION
## Summary
- Adds `version = "0.1.0"` to internal workspace crate dependencies (`pincer-core`, `pincer-macro`, `pincer`)
- Required for publishing to crates.io since path dependencies are stripped during publish

## Context
The release workflow failed because the `pincer` crate couldn't be published - its dependencies on `pincer-core` and `pincer-macro` only had `path` specified, but crates.io requires a `version`.

`pincer-core` and `pincer-macro` were published successfully. After merging this fix, `pincer` needs to be published manually:
```bash
cargo publish -p pincer
```