### PR TITLE
ci: Switch to crates.io trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,6 +12,7 @@ jobs:
     if: ${{ github.repository_owner == 'ilaborie' }}
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +27,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
## Summary

- Replace `CARGO_REGISTRY_TOKEN` secret with OpenID Connect (OIDC) authentication
- Add `id-token: write` permission to enable trusted publishing workflow

## Notes

After merging, you can delete the `CARGO_REGISTRY_TOKEN` secret from GitHub repository settings.