### PR TITLE
docs: Add badges to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Declarative HTTP client for Rust.
 
 [![CI](https://github.com/ilaborie/pincer/actions/workflows/ci.yml/badge.svg)](https://github.com/ilaborie/pincer/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/pincer.svg)](https://crates.io/crates/pincer)
+[![docs.rs](https://img.shields.io/docsrs/pincer)](https://docs.rs/pincer)
+[![Downloads](https://img.shields.io/crates/d/pincer.svg)](https://crates.io/crates/pincer)
+[![MSRV](https://img.shields.io/badge/MSRV-1.92-blue.svg)](https://blog.rust-lang.org/2025/06/26/Rust-1.92.0.html)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
 
 > **Proof of Concept**: This project is experimental and intended for learning and exploration. It is not recommended for production use.

--- a/lib/pincer-core/README.md
+++ b/lib/pincer-core/README.md
@@ -1,5 +1,9 @@
 # pincer-core
 
+[![Crates.io](https://img.shields.io/crates/v/pincer-core.svg)](https://crates.io/crates/pincer-core)
+[![docs.rs](https://img.shields.io/docsrs/pincer-core)](https://docs.rs/pincer-core)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/ilaborie/pincer/blob/main/LICENSE-MIT)
+
 Core types and traits for the [pincer](https://crates.io/crates/pincer) HTTP client.
 
 ## Overview

--- a/lib/pincer-macro/README.md
+++ b/lib/pincer-macro/README.md
@@ -1,5 +1,9 @@
 # pincer-macro
 
+[![Crates.io](https://img.shields.io/crates/v/pincer-macro.svg)](https://crates.io/crates/pincer-macro)
+[![docs.rs](https://img.shields.io/docsrs/pincer-macro)](https://docs.rs/pincer-macro)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/ilaborie/pincer/blob/main/LICENSE-MIT)
+
 Proc-macros for the [pincer](https://crates.io/crates/pincer) HTTP client.
 
 ## Overview

--- a/lib/pincer/README.md
+++ b/lib/pincer/README.md
@@ -1,5 +1,9 @@
 # pincer
 
+[![Crates.io](https://img.shields.io/crates/v/pincer.svg)](https://crates.io/crates/pincer)
+[![docs.rs](https://img.shields.io/docsrs/pincer)](https://docs.rs/pincer)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/ilaborie/pincer/blob/main/LICENSE-MIT)
+
 Declarative HTTP client for Rust.
 
 ## Quick Start


### PR DESCRIPTION
Add crates.io, docs.rs, downloads, MSRV, and license badges to improve project visibility and provide quick access to relevant resources.

## Summary

Brief description of the changes.

## Motivation

Why is this change needed?

## Changes

- Change 1
- Change 2

## Testing

How has this been tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] `cargo fmt --all` has been run
- [ ] `cargo clippy --all-targets --all-features` passes
- [ ] All tests pass (`cargo test --all-features`)
- [ ] Documentation has been updated if needed
- [ ] CHANGELOG.md has been updated if this is a user-facing change

## Related Issues

Closes #
