### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,9 +94,9 @@ insta = { version = "1.42", features = ["yaml"] }
 wiremock = "0.6"
 
 # Internal crates
-pincer-core = { path = "lib/pincer-core", version = "0.1.0" }
-pincer-macro = { path = "lib/pincer-macro", version = "0.1.0" }
-pincer = { path = "lib/pincer", version = "0.1.0" }
+pincer-core = { path = "lib/pincer-core", version = "0.2.0" }
+pincer-macro = { path = "lib/pincer-macro", version = "0.1.1" }
+pincer = { path = "lib/pincer", version = "0.1.1" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/lib/pincer-core/CHANGELOG.md
+++ b/lib/pincer-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/ilaborie/pincer/compare/pincer-core-v0.1.0...pincer-core-v0.2.0) - 2025-12-31
+
+### Added
+
+- *(core)* add PathTemplate and ParameterMetadata for middleware
+- *(core)* add request extensions API for middleware metadata
+
+### Other
+
+- Add badges to README files
+
 ## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-core-v0.1.0) - 2025-12-31
 
 ### Added

--- a/lib/pincer-core/Cargo.toml
+++ b/lib/pincer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pincer-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "Core types and traits for pincer declarative HTTP client"
 edition.workspace = true
 rust-version.workspace = true

--- a/lib/pincer-macro/CHANGELOG.md
+++ b/lib/pincer-macro/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/ilaborie/pincer/compare/pincer-macro-v0.1.0...pincer-macro-v0.1.1) - 2025-12-31
+
+### Added
+
+- *(core)* add PathTemplate and ParameterMetadata for middleware
+
+### Other
+
+- Add badges to README files
+
 ## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-macro-v0.1.0) - 2025-12-31
 
 ### Added

--- a/lib/pincer-macro/Cargo.toml
+++ b/lib/pincer-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pincer-macro"
-version = "0.1.0"
+version = "0.1.1"
 description = "Procedural macros for pincer declarative HTTP client"
 edition.workspace = true
 rust-version.workspace = true

--- a/lib/pincer/CHANGELOG.md
+++ b/lib/pincer/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/ilaborie/pincer/compare/pincer-v0.1.0...pincer-v0.1.1) - 2025-12-31
+
+### Added
+
+- *(core)* add PathTemplate and ParameterMetadata for middleware
+- *(core)* add request extensions API for middleware metadata
+
+### Other
+
+- *(middleware)* simplify header modification using headers_mut()
+- Add badges to README files
+
 ## [0.1.0](https://github.com/ilaborie/pincer/releases/tag/pincer-v0.1.0) - 2025-12-31
 
 ### Added

--- a/lib/pincer/Cargo.toml
+++ b/lib/pincer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pincer"
-version = "0.1.0"
+version = "0.1.1"
 description = "Declarative HTTP client for Rust, inspired by OpenFeign"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `pincer-core`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `pincer-macro`: 0.1.0 -> 0.1.1
* `pincer`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

### ⚠ `pincer-core` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Request is no longer UnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:26
  type Request is no longer RefUnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:26
  type Request is no longer UnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:26
  type Request is no longer RefUnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:26
  type RequestBuilder is no longer UnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:135
  type RequestBuilder is no longer RefUnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:135
  type RequestBuilder is no longer UnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:135
  type RequestBuilder is no longer RefUnwindSafe, in /tmp/.tmpaOmpf4/pincer/lib/pincer-core/src/request.rs:135
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pincer-core`

<blockquote>

## [0.2.0](https://github.com/ilaborie/pincer/compare/pincer-core-v0.1.0...pincer-core-v0.2.0) - 2025-12-31

### Added

- *(core)* add PathTemplate and ParameterMetadata for middleware
- *(core)* add request extensions API for middleware metadata

### Other

- Add badges to README files
</blockquote>

## `pincer-macro`

<blockquote>

## [0.1.1](https://github.com/ilaborie/pincer/compare/pincer-macro-v0.1.0...pincer-macro-v0.1.1) - 2025-12-31

### Added

- *(core)* add PathTemplate and ParameterMetadata for middleware

### Other

- Add badges to README files
</blockquote>

## `pincer`

<blockquote>

## [0.1.1](https://github.com/ilaborie/pincer/compare/pincer-v0.1.0...pincer-v0.1.1) - 2025-12-31

### Added

- *(core)* add PathTemplate and ParameterMetadata for middleware
- *(core)* add request extensions API for middleware metadata

### Other

- *(middleware)* simplify header modification using headers_mut()
- Add badges to README files
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).