### PR TITLE
feat: Add request extensions API with PathTemplate and ParameterMetadata

### DIFF
--- a/lib/pincer-core/src/lib.rs
+++ b/lib/pincer-core/src/lib.rs
@@ -10,12 +10,15 @@
 //! - [`StatusCode`] - HTTP status codes (re-exported from `http` crate)
 //! - [`header`] - HTTP header names (re-exported from `http` crate)
 //! - [`ToQueryPairs`] - Trait for converting types to query parameter pairs
+//! - [`PathTemplate`] - Original path template for middleware access
 
 mod body;
 mod client;
 mod error;
 mod method;
 mod multipart;
+mod param_meta;
+mod path_template;
 pub mod prelude;
 mod request;
 mod response;
@@ -25,6 +28,8 @@ pub use client::{HttpClient, HttpClientExt, PincerClient};
 pub use error::{DefaultErrorDecoder, Error, ErrorDecoder, Result};
 pub use method::Method;
 pub use multipart::{Form, Part};
+pub use param_meta::{ParamLocation, ParamMeta, ParameterMetadata};
+pub use path_template::PathTemplate;
 pub use request::{Request, RequestBuilder};
 pub use response::Response;
 

--- a/lib/pincer-core/src/param_meta.rs
+++ b/lib/pincer-core/src/param_meta.rs
@@ -1,0 +1,137 @@
+//! Parameter metadata for runtime access.
+//!
+//! This module provides types that allow middleware to inspect parameter
+//! information at runtime, useful for `OpenAPI` generation, validation,
+//! and debugging.
+
+use std::fmt;
+
+/// Parameter location in the HTTP request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ParamLocation {
+    /// Path parameter (e.g., `/users/{id}`)
+    Path,
+    /// Query parameter (e.g., `?limit=10`)
+    Query,
+    /// Header parameter
+    Header,
+    /// Request body (JSON)
+    Body,
+    /// Form data (URL-encoded or multipart)
+    Form,
+}
+
+impl fmt::Display for ParamLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Path => write!(f, "path"),
+            Self::Query => write!(f, "query"),
+            Self::Header => write!(f, "header"),
+            Self::Body => write!(f, "body"),
+            Self::Form => write!(f, "form"),
+        }
+    }
+}
+
+/// Metadata about a single parameter.
+///
+/// This struct contains information about a method parameter that
+/// can be used for documentation, validation, or debugging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParamMeta {
+    /// The parameter name as declared in the method signature.
+    pub name: &'static str,
+    /// Where the parameter is sent in the HTTP request.
+    pub location: ParamLocation,
+    /// The Rust type name (e.g., "u64", "Option<String>").
+    pub type_name: &'static str,
+    /// Whether the parameter is required (not an Option type).
+    pub required: bool,
+}
+
+/// All parameter metadata for a method call.
+///
+/// This is stored in request extensions to allow middleware to access
+/// parameter information at runtime.
+///
+/// # Example
+///
+/// ```ignore
+/// // In middleware
+/// if let Some(meta) = request.extensions().get::<ParameterMetadata>() {
+///     println!("Method: {}", meta.method_name);
+///     for param in meta.parameters {
+///         println!("  {}: {} ({:?})", param.name, param.type_name, param.location);
+///     }
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ParameterMetadata {
+    /// The method name that was called.
+    pub method_name: &'static str,
+    /// Metadata for each parameter.
+    pub parameters: &'static [ParamMeta],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn param_location_display() {
+        assert_eq!(ParamLocation::Path.to_string(), "path");
+        assert_eq!(ParamLocation::Query.to_string(), "query");
+        assert_eq!(ParamLocation::Header.to_string(), "header");
+        assert_eq!(ParamLocation::Body.to_string(), "body");
+        assert_eq!(ParamLocation::Form.to_string(), "form");
+    }
+
+    #[test]
+    fn param_meta_construction() {
+        let meta = ParamMeta {
+            name: "id",
+            location: ParamLocation::Path,
+            type_name: "u64",
+            required: true,
+        };
+        assert_eq!(meta.name, "id");
+        assert_eq!(meta.location, ParamLocation::Path);
+        assert_eq!(meta.type_name, "u64");
+        assert!(meta.required);
+    }
+
+    #[test]
+    fn parameter_metadata_construction() {
+        static PARAMS: &[ParamMeta] = &[
+            ParamMeta {
+                name: "id",
+                location: ParamLocation::Path,
+                type_name: "u64",
+                required: true,
+            },
+            ParamMeta {
+                name: "limit",
+                location: ParamLocation::Query,
+                type_name: "Option<u32>",
+                required: false,
+            },
+        ];
+
+        let meta = ParameterMetadata {
+            method_name: "get_user",
+            parameters: PARAMS,
+        };
+
+        assert_eq!(meta.method_name, "get_user");
+        assert_eq!(meta.parameters.len(), 2);
+        assert_eq!(meta.parameters.first().expect("first param").name, "id");
+        assert_eq!(meta.parameters.get(1).expect("second param").name, "limit");
+    }
+
+    #[test]
+    fn parameter_metadata_default() {
+        let meta = ParameterMetadata::default();
+        assert_eq!(meta.method_name, "");
+        assert!(meta.parameters.is_empty());
+    }
+}

--- a/lib/pincer-core/src/path_template.rs
+++ b/lib/pincer-core/src/path_template.rs
@@ -1,0 +1,62 @@
+//! Path template for middleware access.
+
+/// The original path template before parameter substitution.
+///
+/// This is stored in request extensions to allow middleware to access
+/// the template pattern (e.g., `/users/{id}`) rather than the resolved
+/// path (e.g., `/users/123`).
+///
+/// # Example
+///
+/// ```ignore
+/// // In middleware
+/// if let Some(template) = request.extensions().get::<PathTemplate>() {
+///     println!("Path template: {}", template.as_str());
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PathTemplate(&'static str);
+
+impl PathTemplate {
+    /// Create a new path template.
+    #[must_use]
+    pub const fn new(template: &'static str) -> Self {
+        Self(template)
+    }
+
+    /// Get the template string.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        self.0
+    }
+}
+
+impl std::fmt::Display for PathTemplate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for PathTemplate {
+    fn as_ref(&self) -> &str {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_template_as_str() {
+        let template = PathTemplate::new("/users/{id}/posts/{post_id}");
+        assert_eq!(template.as_str(), "/users/{id}/posts/{post_id}");
+    }
+
+    #[test]
+    fn path_template_as_ref() {
+        let template = PathTemplate::new("/users/{id}");
+        let s: &str = template.as_ref();
+        assert_eq!(s, "/users/{id}");
+    }
+}

--- a/lib/pincer/src/lib.rs
+++ b/lib/pincer/src/lib.rs
@@ -44,8 +44,8 @@ pub use tower;
 // Re-export core types
 pub use pincer_core::{
     ContentType, DefaultErrorDecoder, Error, ErrorDecoder, Form, HttpClient, HttpClientExt, Method,
-    Part, PincerClient, Request, RequestBuilder, Response, Result, ToQueryPairs, from_json,
-    to_form, to_json, to_query_string,
+    ParamLocation, ParamMeta, ParameterMetadata, Part, PathTemplate, PincerClient, Request,
+    RequestBuilder, Response, Result, ToQueryPairs, from_json, to_form, to_json, to_query_string,
 };
 
 // Re-export http types for status codes and headers

--- a/lib/pincer/src/middleware/basic_auth.rs
+++ b/lib/pincer/src/middleware/basic_auth.rs
@@ -87,24 +87,14 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, request: Request<Bytes>) -> Self::Future {
-        // Add the Authorization header
-        let (method, url, mut headers, body, extensions) = request.into_parts();
-        headers.insert(
+    fn call(&mut self, mut request: Request<Bytes>) -> Self::Future {
+        request.headers_mut().insert(
             "Authorization".to_string(),
             format!("Basic {}", self.encoded_credentials),
         );
 
-        let new_request = Request::from_parts(
-            method,
-            url,
-            headers,
-            Some(body.unwrap_or_default()),
-            extensions,
-        );
-
         let mut inner = self.inner.clone();
-        Box::pin(async move { inner.call(new_request).await })
+        Box::pin(async move { inner.call(request).await })
     }
 }
 

--- a/lib/pincer/src/middleware/basic_auth.rs
+++ b/lib/pincer/src/middleware/basic_auth.rs
@@ -89,16 +89,19 @@ where
 
     fn call(&mut self, request: Request<Bytes>) -> Self::Future {
         // Add the Authorization header
-        let (method, url, mut headers, body) = request.into_parts();
+        let (method, url, mut headers, body, extensions) = request.into_parts();
         headers.insert(
             "Authorization".to_string(),
             format!("Basic {}", self.encoded_credentials),
         );
 
-        let new_request = Request::builder(method, url)
-            .headers(headers)
-            .body(body.unwrap_or_default())
-            .build();
+        let new_request = Request::from_parts(
+            method,
+            url,
+            headers,
+            Some(body.unwrap_or_default()),
+            extensions,
+        );
 
         let mut inner = self.inner.clone();
         Box::pin(async move { inner.call(new_request).await })

--- a/lib/pincer/src/middleware/bearer_auth.rs
+++ b/lib/pincer/src/middleware/bearer_auth.rs
@@ -80,24 +80,14 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, request: Request<Bytes>) -> Self::Future {
-        // Add the Authorization header
-        let (method, url, mut headers, body, extensions) = request.into_parts();
-        headers.insert(
+    fn call(&mut self, mut request: Request<Bytes>) -> Self::Future {
+        request.headers_mut().insert(
             "Authorization".to_string(),
             format!("Bearer {}", self.token),
         );
 
-        let new_request = Request::from_parts(
-            method,
-            url,
-            headers,
-            Some(body.unwrap_or_default()),
-            extensions,
-        );
-
         let mut inner = self.inner.clone();
-        Box::pin(async move { inner.call(new_request).await })
+        Box::pin(async move { inner.call(request).await })
     }
 }
 

--- a/lib/pincer/src/middleware/bearer_auth.rs
+++ b/lib/pincer/src/middleware/bearer_auth.rs
@@ -82,16 +82,19 @@ where
 
     fn call(&mut self, request: Request<Bytes>) -> Self::Future {
         // Add the Authorization header
-        let (method, url, mut headers, body) = request.into_parts();
+        let (method, url, mut headers, body, extensions) = request.into_parts();
         headers.insert(
             "Authorization".to_string(),
             format!("Bearer {}", self.token),
         );
 
-        let new_request = Request::builder(method, url)
-            .headers(headers)
-            .body(body.unwrap_or_default())
-            .build();
+        let new_request = Request::from_parts(
+            method,
+            url,
+            headers,
+            Some(body.unwrap_or_default()),
+            extensions,
+        );
 
         let mut inner = self.inner.clone();
         Box::pin(async move { inner.call(new_request).await })

--- a/lib/pincer/src/middleware/decompression.rs
+++ b/lib/pincer/src/middleware/decompression.rs
@@ -121,15 +121,18 @@ where
         let request = if request.headers().contains_key("accept-encoding") {
             request
         } else {
-            let (method, url, mut headers, body) = request.into_parts();
+            let (method, url, mut headers, body, extensions) = request.into_parts();
             headers.insert(
                 "accept-encoding".to_string(),
                 "gzip, deflate, br, zstd".to_string(),
             );
-            Request::builder(method, url)
-                .headers(headers)
-                .body(body.unwrap_or_default())
-                .build()
+            Request::from_parts(
+                method,
+                url,
+                headers,
+                Some(body.unwrap_or_default()),
+                extensions,
+            )
         };
 
         let mut inner = self.inner.clone();

--- a/lib/pincer/src/middleware/decompression.rs
+++ b/lib/pincer/src/middleware/decompression.rs
@@ -116,24 +116,14 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, request: Request<Bytes>) -> Self::Future {
+    fn call(&mut self, mut request: Request<Bytes>) -> Self::Future {
         // Add Accept-Encoding header if not present
-        let request = if request.headers().contains_key("accept-encoding") {
-            request
-        } else {
-            let (method, url, mut headers, body, extensions) = request.into_parts();
-            headers.insert(
+        if !request.headers().contains_key("accept-encoding") {
+            request.headers_mut().insert(
                 "accept-encoding".to_string(),
                 "gzip, deflate, br, zstd".to_string(),
             );
-            Request::from_parts(
-                method,
-                url,
-                headers,
-                Some(body.unwrap_or_default()),
-                extensions,
-            )
-        };
+        }
 
         let mut inner = self.inner.clone();
 

--- a/lib/pincer/src/middleware/follow_redirect.rs
+++ b/lib/pincer/src/middleware/follow_redirect.rs
@@ -175,17 +175,15 @@ where
 
                 // Build the new request
                 // For 303 redirects (and 301/302 to GET), we don't forward the body
-                let (_, _, headers, body) = current_request.into_parts();
+                let (_, _, headers, body, extensions) = current_request.into_parts();
                 let body = if matches!(new_method, Method::Get | Method::Head) {
                     Bytes::new()
                 } else {
                     body.unwrap_or_default()
                 };
 
-                current_request = Request::builder(new_method, new_url)
-                    .headers(headers)
-                    .body(body)
-                    .build();
+                current_request =
+                    Request::from_parts(new_method, new_url, headers, Some(body), extensions);
 
                 redirects += 1;
             }


### PR DESCRIPTION
## Summary

- Add request extensions API for attaching typed metadata to requests (Issue #6)
- Preserve path templates for middleware access (Issue #7)
- Expose parameter metadata at runtime for OpenAPI generation (Issue #8)
- Simplify middleware by using `headers_mut()` directly

## Changes

### Request Extensions API
- Added `extensions` field to `Request<B>` using `http::Extensions`
- Added `extensions()` and `extensions_mut()` accessors
- Added `from_parts()` constructor for middleware reconstruction
- Updated `into_parts()` to return 5-tuple including extensions
- `RequestBuilder` gains `.extension()` and `.extensions()` methods

### PathTemplate
- New type storing original path template (e.g., `/users/{id}`)
- Automatically injected into request extensions by macro
- Enables route-based logging and metrics grouping

### ParameterMetadata
- `ParamLocation` enum: Path, Query, Header, Body, Form
- `ParamMeta` struct: name, location, type_name, required
- `ParameterMetadata`: method_name + parameters slice
- Automatically injected by macro for OpenAPI generation

### Middleware Simplification
- Auth middleware now uses `headers_mut()` instead of decompose/reconstruct
- Decompression middleware simplified similarly
- Redirect middleware updated to preserve extensions via `from_parts()`

## Test plan

- [x] All 218 existing tests pass
- [x] New unit tests for extensions API
- [x] New unit tests for PathTemplate and ParameterMetadata
- [x] `mise check` passes (format, clippy, tests, doctests)

Closes #6, closes #7, closes #8